### PR TITLE
Fix project template -- resolves dynod/nmk#310

### DIFF
--- a/src/nmk_python/_buildenv/template.py
+++ b/src/nmk_python/_buildenv/template.py
@@ -62,8 +62,7 @@ class NmkPythonProjectTemplate(NmkBaseProjectTemplate):
             "config.venvPkgDeps": "\nDevelopment dependencies (tools)",
             "config.venvArchiveDeps": "\nDevelopment dependencies (tools, from local files)",
             "config.pythonPackageRequirements": "\nPython package dependencies",
-            "config.pythonPackage": "\nPython package name",
-            "config.pythonProjectFileItems": "\nExtra projects settings",
+            "config.pythonProjectFileItems": "\nExtra project settings",
         }
 
     def handle_dependencies(self, packages: list[str]) -> dict[str, NmkConfigType]:
@@ -110,6 +109,10 @@ class NmkPythonProjectTemplate(NmkBaseProjectTemplate):
 
     @property
     def config_items(self) -> dict[str, NmkConfigType]:
-        return {
-            "pythonProjectFileItems": {"project": {"description": "Insert here a oneline description of your project"}},
-        }
+        items = dict(super().config_items)
+        items.update(
+            {
+                "pythonProjectFileItems": {"project": {"description": "Insert here a oneline description of your project"}},
+            }
+        )
+        return items

--- a/src/nmk_python/backends/uv_build_backend.py
+++ b/src/nmk_python/backends/uv_build_backend.py
@@ -52,5 +52,5 @@ class UvBuildBackend(PythonBuildBackend):
         return build_dir / wheel_sub_dir / built_wheel_name
 
     def uninstall_wheels(self, wheel_names: list[str]):
-        # Same as setup
-        self._env_backend.upgrade(full=False, only_deps=True)
+        # Same as setup, just don't print updates (will be done by uninstall builder)
+        self._env_backend.upgrade(full=False, only_deps=True, print_updates=False)


### PR DESCRIPTION
- missing projectName when nmk-python is used alone
- remove useless print on uninstall